### PR TITLE
add loadStarted event to web-view module

### DIFF
--- a/ui/web-view/web-view-common.ts
+++ b/ui/web-view/web-view-common.ts
@@ -5,6 +5,7 @@ import proxy = require("ui/core/proxy");
 
 export module knownEvents {
     export var finished: string = "finished";
+    export var loadStarted: string = "loadStarted";
 }
 var urlProperty = new dependencyObservable.Property(
     "url",
@@ -51,6 +52,18 @@ export class WebView extends view.View implements definition.WebView {
 
         var args = <definition.FinishedEventData>{
             eventName: knownEvents.finished,
+            object: this,
+            url: url,
+            error: error
+        };
+
+        this.notify(args);
+    }
+
+    public _onLoadStarted(url: string, error?: string) {
+
+        var args = <definition.FinishedEventData>{
+            eventName: knownEvents.loadStarted,
             object: this,
             url: url,
             error: error

--- a/ui/web-view/web-view.ios.ts
+++ b/ui/web-view/web-view.ios.ts
@@ -18,6 +18,14 @@ class UIWebViewDelegateImpl extends NSObject implements UIWebViewDelegate {
         return this;
     }
     
+    public webViewShouldStartLoadWithRequestNavigationType(webView: UIWebView, request:NSURLRequest, navigationType:number) {
+        if (request.URL) {
+            trace.write("UIWebViewDelegateClass.webViewShouldStartLoadWithRequestNavigationType()", trace.categories.Debug);
+            this._owner._onLoadStarted(request.URL.absoluteString);
+        }
+        return true;
+    }
+
     public webViewDidStartLoad(webView: UIWebView) {
         trace.write("UIWebViewDelegateClass.webViewDidStartLoad()", trace.categories.Debug);
     }


### PR DESCRIPTION
Added a wrapper for the iOS WebView `shouldStartLoadWithRequest` event mapped to `loadStarted` event in the common wrapper.  This event fires for each frame that is loaded in the WebView.

Android implementation pending...