### PR TITLE
Allow Observable to be extended

### DIFF
--- a/data/observable/observable.d.ts
+++ b/data/observable/observable.d.ts
@@ -50,6 +50,16 @@ declare module "data/observable" {
         typeName: string;
 
         /**
+         * Alias to Observable.prototype
+         */
+        static fn;
+
+        /**
+         * The `init` method will be called when a new instance is created
+         */
+        init();
+
+        /**
          * Shortcut alias to the addEventListener method.
          */
         on(eventNames: string, callback: (data: EventData) => void, thisArg?: any);
@@ -96,6 +106,13 @@ declare module "data/observable" {
          * @param eventName The name of the event to check for.
          */
         hasListeners(eventName: string): boolean;
+
+        /**
+         * Extends Observable with new methods. Allows inheritance.
+         * @param proto A key/value pair of all additional methods that the new class will have.
+         * @returns extended Observable
+         */
+        static extends(proto: Object): Observable;
 
         //@private
         /**

--- a/utils/module-merge.ts
+++ b/utils/module-merge.ts
@@ -1,7 +1,12 @@
 ﻿// This method iterates all the keys in the source exports object and copies them to the destination exports one.
 // Note: the method will not check for naming collisions and will override any already existing entries in the destination exports.
-export var merge = function (sourceExports: any, destExports: any) {
+export var merge = function (sourceExports: any, destExports: any, deep?: boolean) {
     for (var key in sourceExports) {
-        destExports[key] = sourceExports[key];
+        if (deep && typeof sourceExports[key] === "object") {
+            destExports[key] = {};
+            merge(sourceExports[key], destExports[key], true);
+        } else {
+            destExports[key] = sourceExports[key];
+        }
     }
 }


### PR DESCRIPTION
This will allow simular coding style and Observable inheritance

```javascript
MainViewModelBase = observable.Observable.extends({
    username: "",
    password: "",

    init: function() {
        observable.Observable.fn.init.apply(this, arguments);
    },

    onLogin: function() {
        // do some stuff
    }
});

OtherLogin = MainViewModelBase.extends({
    additionalProperty: null,

    init: function() {
        MainViewModelBase.fn.init.apply(this, arguments);
    }
})
```