### PR TITLE
added ability to retrieve device manufacturer

### DIFF
--- a/platform/platform.android.ts
+++ b/platform/platform.android.ts
@@ -12,6 +12,7 @@ export module platformNames {
 // It is not meant to be initialized - thus it is not capitalized
 export class device implements definition.device {
     private static MIN_TABLET_PIXELS = 600;
+    private static _manufacturer: string;
     private static _model: string;
     private static _osVersion: string;
     private static _sdkVersion: string;
@@ -20,6 +21,14 @@ export class device implements definition.device {
 
     static get os(): string {
         return platformNames.android;
+    }
+
+    static get manufacturer(): string {
+        if (!device._manufacturer) {
+            device._manufacturer = android.os.Build.MANUFACTURER;
+        }
+
+        return device._manufacturer;
     }
 
     static get osVersion(): string {

--- a/platform/platform.d.ts
+++ b/platform/platform.d.ts
@@ -17,6 +17,12 @@ declare module "platform" {
      */
     export class device {
         /**
+         * Gets the manufacturer of the device.
+         * For example: "Apple" or "HTC" or "Samsung".
+         */
+        static manufacturer: string;
+
+        /**
          * Gets the model of the device.
          * For example: "Nexus 5" or "iPhone.
          */

--- a/platform/platform.ios.ts
+++ b/platform/platform.ios.ts
@@ -15,6 +15,10 @@ export class device implements definition.device {
     private static _sdkVersion: string;
     private static _deviceType: string;
 
+    static get manufacturer(): string {
+        return "Apple";
+    }
+
     static get os(): string {
         return platformNames.ios;
     }


### PR DESCRIPTION
As part of issue #268 the ability to get the Device Manufacturer was requested.

On iOS this will never change so we can return "Apple".

On Android we use android.os.Build.MANUFACTURER.