### PR TITLE
Added user agent string and selected language to the platform module

### DIFF
--- a/platform/platform.android.ts
+++ b/platform/platform.android.ts
@@ -18,6 +18,8 @@ export class device implements definition.device {
     private static _sdkVersion: string;
     private static _deviceType: string;
     private static _uuid: string;
+    private static _userAgent: string;
+    private static _language: string;
 
     static get os(): string {
         return platformNames.android;
@@ -80,6 +82,25 @@ export class device implements definition.device {
         }
         
         return device._uuid;
+    }
+
+    static get userAgent(): string {
+        if (!device._userAgent) {
+            var context = application.android.context;
+            device._userAgent = new android.webkit.WebView(context).getSettings().getUserAgentString();
+        }
+        
+        return device._userAgent;
+    }
+
+    static get language(): string {
+        if (!device._language) {
+            var context = application.android.context;
+            var locale = context.getResources().getConfiguration().locale;
+            device._language = locale.getDefault().toString();
+        }
+        
+        return device._language;
     }
 }
 

--- a/platform/platform.android.ts
+++ b/platform/platform.android.ts
@@ -18,7 +18,6 @@ export class device implements definition.device {
     private static _sdkVersion: string;
     private static _deviceType: string;
     private static _uuid: string;
-    private static _userAgent: string;
     private static _language: string;
 
     static get os(): string {
@@ -82,15 +81,6 @@ export class device implements definition.device {
         }
         
         return device._uuid;
-    }
-
-    static get userAgent(): string {
-        if (!device._userAgent) {
-            var context = application.android.context;
-            device._userAgent = new android.webkit.WebView(context).getSettings().getUserAgentString();
-        }
-        
-        return device._userAgent;
     }
 
     static get language(): string {

--- a/platform/platform.d.ts
+++ b/platform/platform.d.ts
@@ -58,12 +58,6 @@ declare module "platform" {
          static uuid: string;
 
         /**
-         * Gets the user agent string as it would be reported by the
-         * device built-in web browser control
-         */
-        static userAgent: string;
-
-        /**
          * Gets the preferred language. For example "en" or "en_US"
          */
         static language: string;

--- a/platform/platform.d.ts
+++ b/platform/platform.d.ts
@@ -56,6 +56,17 @@ declare module "platform" {
          * Gets the uuid
          */
          static uuid: string;
+
+        /**
+         * Gets the user agent string as it would be reported by the
+         * device built-in web browser control
+         */
+        static userAgent: string;
+
+        /**
+         * Gets the preferred language. For example "en" or "en_US"
+         */
+        static language: string;
     }
 
     /**

--- a/platform/platform.ios.ts
+++ b/platform/platform.ios.ts
@@ -14,7 +14,6 @@ export class device implements definition.device {
     private static _osVersion: string;
     private static _sdkVersion: string;
     private static _deviceType: string;
-    private static _userAgent: string;
     private static _language: string;
 
     static get manufacturer(): string {
@@ -75,14 +74,6 @@ export class device implements definition.device {
         }
 
         return app_uuid;
-    }
-
-    static get userAgent(): string {
-        if (!device._userAgent) {
-            device._userAgent = new UIWebView().stringByEvaluatingJavaScriptFromString('navigator.userAgent');
-        }
-        
-        return device._userAgent;
     }
 
     static get language(): string {

--- a/platform/platform.ios.ts
+++ b/platform/platform.ios.ts
@@ -14,6 +14,8 @@ export class device implements definition.device {
     private static _osVersion: string;
     private static _sdkVersion: string;
     private static _deviceType: string;
+    private static _userAgent: string;
+    private static _language: string;
 
     static get manufacturer(): string {
         return "Apple";
@@ -73,6 +75,23 @@ export class device implements definition.device {
         }
 
         return app_uuid;
+    }
+
+    static get userAgent(): string {
+        if (!device._userAgent) {
+            device._userAgent = new UIWebView().stringByEvaluatingJavaScriptFromString('navigator.userAgent');
+        }
+        
+        return device._userAgent;
+    }
+
+    static get language(): string {
+        if (!device._language) {
+            var languages = NSLocale.preferredLanguages();
+            device._language = languages[0];
+        }
+        
+        return device._language;
     }
 }
 


### PR DESCRIPTION
1. At the Telerik Analytics Team we would like to have a NativeScript SDK that would allow app developers to take advantage of [our service](http://docs.telerik.com/platform/analytics/). In order to report some additional device information we would need the platform module to expose the user's language preferences and user agent string (as it would have been reported by the native WebBrowser control). This information is already reported by our SDK on different platforms and is later visualized in the Analytics Dashboard.
2. The proposed solution is to add to the existing platform module this information.